### PR TITLE
Removed extra example for elsif to match README rspec output.

### DIFF
--- a/Assignments/Lesson01-Assignment01-Case-Statement/student-start/spec/lesson1_spec.rb
+++ b/Assignments/Lesson01-Assignment01-Case-Statement/student-start/spec/lesson1_spec.rb
@@ -22,10 +22,6 @@ describe "lesson1" do
       expect(srcCode).not_to include("elsif")
     end
 
-    it "remove elsif clause" do
-      expect(srcCode).not_to include("elsif")
-    end
-
     it "missing case" do
       expect(srcCode).to include("case")
     end


### PR DESCRIPTION
I removed what appeared to be an extra example for an elsif clause to match rspec output shown in README for the assignment.
